### PR TITLE
change server "name" by "server_id"

### DIFF
--- a/provider/resource_server.go
+++ b/provider/resource_server.go
@@ -18,7 +18,7 @@ func resourceServer() *schema.Resource {
 		Delete: resourceServerNone,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"server_id": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
 			},
@@ -200,7 +200,7 @@ func resourceServerRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	id := d.Get("name").(int)
+	id := d.Get("server_id").(int)
 	rpns, err := getRPNbyServer(client, id)
 	if err != nil {
 		return err
@@ -211,7 +211,7 @@ func resourceServerRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getServer(c online.Client, d *schema.ResourceData) (*online.Server, error) {
-	id := d.Get("name").(int)
+	id := d.Get("server_id").(int)
 	d.SetId(string(id))
 
 	return c.Server(id)

--- a/provider/resource_server_test.go
+++ b/provider/resource_server_test.go
@@ -13,7 +13,7 @@ func TestResourceServer(t *testing.T) {
 			ImportStateVerify: true,
 			Config: `
 				resource "online_server" "test" {
-	 				name = "105770"
+					server_id = "105770"
 					hostname = "mvp"
 				}
 			`,
@@ -39,7 +39,7 @@ func TestResourceServerRPNAdd(t *testing.T) {
 				}
 
 				resource "online_server" "test" {
-	 				name = "105770"
+					server_id = "105770"
 					hostname = "mvp"
 
 					private_interface {
@@ -70,7 +70,7 @@ func TestResourceServerRPNAdd(t *testing.T) {
 				}
 
 				resource "online_server" "test" {
-	 				name = "105770"
+					server_id = "105770"
 					hostname = "mvp"
 
 					private_interface {
@@ -109,7 +109,7 @@ func TestResourceServerRPNDelete(t *testing.T) {
 				}
 
 				resource "online_server" "test" {
-	 				name = "105770"
+					server_id = "105770"
 					hostname = "mvp"
 
 					private_interface {
@@ -135,14 +135,14 @@ func TestResourceServerRPNDelete(t *testing.T) {
 				}
 
 				resource "online_server" "test" {
-	 				name = "105770"
+					server_id = "105770"
 					hostname = "mvp"
 
 					private_interface {}
 				}
 
 				resource "online_server" "foo" {
-	 				name = "105771"
+					server_id = "105771"
 					hostname = "mvp"
 
 					private_interface {


### PR DESCRIPTION
"name" suggests a string instead of an integer, which is very confusing.
We cannot use "id" as it is reserved by terraform

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>