### PR TITLE
Remove multiple instances of the word 'the'

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -10,7 +10,7 @@ import (
 
 const TokenEnvVar = "ONLINE_TOKEN"
 
-// globalCache keeps the the internal implate types generated  by the different
+// globalCache keeps the internal implate types generated  by the different
 // data resources with the goal to be reused by the other resources. The key of
 // the maps are the name of resource.
 var globalCache = newCache()

--- a/vendor/github.com/bgentry/go-netrc/netrc/netrc.go
+++ b/vendor/github.com/bgentry/go-netrc/netrc/netrc.go
@@ -486,7 +486,7 @@ func ParseFile(filename string) (*Netrc, error) {
 	return Parse(fd)
 }
 
-// Parse parses from the the Reader r as a netrc file and returns the set of
+// Parse parses from the Reader r as a netrc file and returns the set of
 // machine information and macros defined in it. The ``default'' machine,
 // which is intended to be used when no machine name matches, is identified
 // by an empty machine name. There can be only one ``default'' machine.

--- a/vendor/github.com/davecgh/go-spew/spew/config.go
+++ b/vendor/github.com/davecgh/go-spew/spew/config.go
@@ -228,7 +228,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), and %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/davecgh/go-spew/spew/doc.go
+++ b/vendor/github.com/davecgh/go-spew/spew/doc.go
@@ -165,7 +165,7 @@ standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/davecgh/go-spew/spew/format.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format.go
@@ -405,7 +405,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/hashicorp/hcl2/hcl/spec.md
+++ b/vendor/github.com/hashicorp/hcl2/hcl/spec.md
@@ -497,7 +497,7 @@ producing an unknown value of the target type.
 
 Conversion of any value _to_ the dynamic pseudo-type is a no-op. The result
 is the input value, verbatim. This is the only situation where the conversion
-result value is not of the the given target type.
+result value is not of the given target type.
 
 ### Primitive Type Conversions
 

--- a/vendor/github.com/hashicorp/hcl2/hcl/traversal_for_expr.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/traversal_for_expr.go
@@ -13,7 +13,7 @@ package hcl
 //
 // In most cases the calling application is interested in the value
 // that results from an expression, but in rarer cases the application
-// needs to see the the name of the variable and subsequent
+// needs to see the name of the variable and subsequent
 // attributes/indexes itself, for example to allow users to give references
 // to the variables themselves rather than to their values. An implementer
 // of this function should at least support attribute and index steps.

--- a/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
+++ b/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
@@ -525,7 +525,7 @@ func interpolationFuncPathExpand() ast.Function {
 	}
 }
 
-// interpolationFuncCeil returns the the least integer value greater than or equal to the argument
+// interpolationFuncCeil returns the least integer value greater than or equal to the argument
 func interpolationFuncCeil() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeFloat},

--- a/vendor/github.com/ulikunitz/xz/TODO.md
+++ b/vendor/github.com/ulikunitz/xz/TODO.md
@@ -277,7 +277,7 @@ almost all files from lzma.
 Removed only a TODO item. 
 
 However in Francesco Campoy's presentation "Go for Javaneros
-(Javaïstes?)" is the the idea that using an embedded field E, all the
+(Javaïstes?)" is the idea that using an embedded field E, all the
 methods of E will be defined on T. If E is an interface T satisfies E.
 
 https://talks.golang.org/2014/go4java.slide#51

--- a/vendor/github.com/ulikunitz/xz/lzma/buffer.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/buffer.go
@@ -11,7 +11,7 @@ import (
 // buffer provides a circular buffer of bytes. If the front index equals
 // the rear index the buffer is empty. As a consequence front cannot be
 // equal rear for a full buffer. So a full buffer has a length that is
-// one byte less the the length of the data slice.
+// one byte less the length of the data slice.
 type buffer struct {
 	data  []byte
 	front int

--- a/vendor/github.com/ulikunitz/xz/lzma/reader.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/reader.go
@@ -52,7 +52,7 @@ func NewReader(lzma io.Reader) (r *Reader, err error) {
 }
 
 // NewReader creates a new reader for an LZMA stream in the classic
-// format. The function reads and verifies the the header of the LZMA
+// format. The function reads and verifies the header of the LZMA
 // stream.
 func (c ReaderConfig) NewReader(lzma io.Reader) (r *Reader, err error) {
 	if err = c.Verify(); err != nil {

--- a/vendor/golang.org/x/text/internal/gen/code.go
+++ b/vendor/golang.org/x/text/internal/gen/code.go
@@ -48,7 +48,7 @@ func NewCodeWriter() *CodeWriter {
 }
 
 // WriteGoFile appends the buffer with the total size of all created structures
-// and writes it as a Go file to the the given file with the given package name.
+// and writes it as a Go file to the given file with the given package name.
 func (w *CodeWriter) WriteGoFile(filename, pkg string) {
 	f, err := os.Create(filename)
 	if err != nil {
@@ -61,7 +61,7 @@ func (w *CodeWriter) WriteGoFile(filename, pkg string) {
 }
 
 // WriteVersionedGoFile appends the buffer with the total size of all created
-// structures and writes it as a Go file to the the given file with the given
+// structures and writes it as a Go file to the given file with the given
 // package name and build tags for the current Unicode version,
 func (w *CodeWriter) WriteVersionedGoFile(filename, pkg string) {
 	tags := buildTags()
@@ -79,7 +79,7 @@ func (w *CodeWriter) WriteVersionedGoFile(filename, pkg string) {
 }
 
 // WriteGo appends the buffer with the total size of all created structures and
-// writes it as a Go file to the the given writer with the given package name.
+// writes it as a Go file to the given writer with the given package name.
 func (w *CodeWriter) WriteGo(out io.Writer, pkg, tags string) (n int, err error) {
 	sz := w.Size
 	w.WriteComment("Total table size %d bytes (%dKiB); checksum: %X\n", sz, sz/1024, w.Hash.Sum32())

--- a/vendor/golang.org/x/text/internal/triegen/triegen.go
+++ b/vendor/golang.org/x/text/internal/triegen/triegen.go
@@ -53,7 +53,7 @@
 //		Indexes of starter blocks in case of multiple trie roots.
 //
 // It is recommended that users test the generated trie by checking the returned
-// value for every rune. Such exhaustive tests are possible as the the number of
+// value for every rune. Such exhaustive tests are possible as the number of
 // runes in Unicode is limited.
 package triegen // import "golang.org/x/text/internal/triegen"
 

--- a/vendor/golang.org/x/text/language/parse.go
+++ b/vendor/golang.org/x/text/language/parse.go
@@ -236,7 +236,7 @@ func Parse(s string) (t Tag, err error) {
 // value. All other values are preserved. It accepts tags in the BCP 47 format
 // and extensions to this standard defined in
 // http://www.unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers.
-// The resulting tag is canonicalized using the the canonicalization type c.
+// The resulting tag is canonicalized using the canonicalization type c.
 func (c CanonType) Parse(s string) (t Tag, err error) {
 	// TODO: consider supporting old-style locale key-value pairs.
 	if s == "" {


### PR DESCRIPTION
Signed-off-by: Adam Curtis <adamcurtisvt@gmail.com>

Removed multiple instances of the word "the" within the comments.